### PR TITLE
Feat/file dialogs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Build output
 build/
+build-fetch/
+build-verify/
 out/
 cmake-build-*/
 

--- a/editor/CMakeLists.txt
+++ b/editor/CMakeLists.txt
@@ -8,6 +8,8 @@ add_executable(editor
     src/main.cpp
     src/editor.cpp
     src/editor.h
+    src/file_dialog.cpp
+    src/file_dialog.h
     src/hierarchy_panel.cpp
     src/hierarchy_panel.h
     src/inspector_panel.cpp
@@ -68,6 +70,8 @@ source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES
     src/main.cpp
     src/editor.cpp
     src/editor.h
+    src/file_dialog.cpp
+    src/file_dialog.h
     src/hierarchy_panel.cpp
     src/hierarchy_panel.h
     src/inspector_panel.cpp

--- a/editor/src/editor.cpp
+++ b/editor/src/editor.cpp
@@ -1,9 +1,11 @@
 #include "editor.h"
 
 #include "engine_viewport.h"
+#include "file_dialog.h"
 #include "hierarchy_panel.h"
 #include "inspector_panel.h"
 
+#include "core/log.h"
 #include "transform.h"
 #include "scene/components/components.h"
 
@@ -11,6 +13,7 @@
 #include <QHBoxLayout>
 #include <QKeySequence>
 #include <QMainWindow>
+#include <QMenuBar>
 #include <QShortcut>
 #include <QSizePolicy>
 #include <QVBoxLayout>
@@ -80,6 +83,32 @@ void Editor::run() {
     emit selection_changed();
 
     window.setCentralWidget(central);
+
+    QMenu* const file_menu = window.menuBar()->addMenu(tr("&File"));
+    QAction* const open_action = file_menu->addAction(tr("&Open..."));
+    open_action->setShortcut(QKeySequence::Open);
+    QObject::connect(open_action, &QAction::triggered, &window, [&window]() {
+        if (const auto path = ngin::editor::open_file_dialog(&window, {.title = tr("Open")})) {
+            NGIN_INFO("File > Open (not implemented): {}", path->toStdString());
+        }
+    });
+
+    QAction* const save_action = file_menu->addAction(tr("&Save..."));
+    save_action->setShortcut(QKeySequence::Save);
+    QObject::connect(save_action, &QAction::triggered, &window, [&window]() {
+        if (const auto path = ngin::editor::save_file_dialog(
+                &window,
+                {
+                    .title = tr("Save"),
+                    .name_filter = QStringLiteral("Scene (*.scene);;All files (*.*)"),
+                    .default_file_name = QStringLiteral("untitled.scene"),
+                    .default_suffix = QStringLiteral("scene"),
+                }
+            )) {
+            NGIN_INFO("File > Save (not implemented): {}", path->toStdString());
+        }
+    });
+
     window.show();
 
     QApplication::exec();

--- a/editor/src/file_dialog.cpp
+++ b/editor/src/file_dialog.cpp
@@ -1,0 +1,100 @@
+#include "file_dialog.h"
+
+#include <QApplication>
+#include <QDir>
+#include <QFileInfo>
+#include <QWidget>
+
+namespace ngin::editor {
+
+namespace {
+
+QWidget* effective_parent(QWidget* parent) {
+    if (parent != nullptr) {
+        return parent;
+    }
+    return QApplication::activeWindow();
+}
+
+QString effective_name_filter(const FileDialogOptions& opts) {
+    if (opts.name_filter.isEmpty()) {
+        return QStringLiteral("All files (*.*)");
+    }
+    return opts.name_filter;
+}
+
+QString save_dialog_start_path(const FileDialogOptions& opts) {
+    const QString base_dir = opts.directory.isEmpty() ? QDir::homePath() : opts.directory;
+
+    if (opts.default_file_name.isEmpty()) {
+        return opts.directory.isEmpty() ? QDir::homePath() : opts.directory;
+    }
+
+    const QFileInfo name_info(opts.default_file_name);
+    if (name_info.isAbsolute()) {
+        return opts.default_file_name;
+    }
+    return QDir(base_dir).filePath(opts.default_file_name);
+}
+
+QString maybe_apply_default_suffix(const QString& path, const QString& default_suffix) {
+    if (default_suffix.isEmpty()) {
+        return path;
+    }
+
+    QString suffix = default_suffix;
+    if (suffix.startsWith(QLatin1Char('.'))) {
+        suffix = suffix.mid(1);
+    }
+    if (suffix.isEmpty()) {
+        return path;
+    }
+
+    if (!QFileInfo(path).suffix().isEmpty()) {
+        return path;
+    }
+
+    return path + QLatin1Char('.') + suffix;
+}
+
+} // namespace
+
+std::optional<QString> open_file_dialog(QWidget* parent, const FileDialogOptions& opts) {
+    QWidget* const p = effective_parent(parent);
+    const QString caption =
+        opts.title.isEmpty() ? QStringLiteral("Open File") : opts.title;
+    const QString path = QFileDialog::getOpenFileName(
+        p,
+        caption,
+        opts.directory,
+        effective_name_filter(opts),
+        nullptr,
+        opts.options
+    );
+    if (path.isEmpty()) {
+        return std::nullopt;
+    }
+    return path;
+}
+
+std::optional<QString> save_file_dialog(QWidget* parent, const FileDialogOptions& opts) {
+    QWidget* const p = effective_parent(parent);
+    const QString caption =
+        opts.title.isEmpty() ? QStringLiteral("Save File") : opts.title;
+    const QString start_path = save_dialog_start_path(opts);
+    QString path = QFileDialog::getSaveFileName(
+        p,
+        caption,
+        start_path,
+        effective_name_filter(opts),
+        nullptr,
+        opts.options
+    );
+    if (path.isEmpty()) {
+        return std::nullopt;
+    }
+    path = maybe_apply_default_suffix(path, opts.default_suffix);
+    return path;
+}
+
+} // namespace ngin::editor

--- a/editor/src/file_dialog.cpp
+++ b/editor/src/file_dialog.cpp
@@ -27,7 +27,7 @@ QString save_dialog_start_path(const FileDialogOptions& opts) {
     const QString base_dir = opts.directory.isEmpty() ? QDir::homePath() : opts.directory;
 
     if (opts.default_file_name.isEmpty()) {
-        return opts.directory.isEmpty() ? QDir::homePath() : opts.directory;
+        return base_dir;
     }
 
     const QFileInfo name_info(opts.default_file_name);

--- a/editor/src/file_dialog.h
+++ b/editor/src/file_dialog.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <QFileDialog>
+#include <QString>
+
+#include <optional>
+
+class QWidget;
+
+namespace ngin::editor {
+
+/// Options for @ref open_file_dialog and @ref save_file_dialog.
+struct FileDialogOptions {
+    /// Window title. Default: "Open File" / "Save File".
+    QString title;
+    /// Initial directory. Empty uses the platform default (often last-used or home).
+    QString directory;
+    /// Filter string, e.g. `"JSON (*.json);;All files (*.*)"`. Empty uses `"All files (*.*)"`.
+    QString name_filter;
+    /// Save only: suggested file name (relative to @a directory unless absolute).
+    QString default_file_name;
+    /// Save only: if the chosen path has no extension, append `.<default_suffix>` (without dot).
+    QString default_suffix;
+    QFileDialog::Options options = QFileDialog::Options();
+};
+
+/// Modal open-file dialog. Call from the GUI thread only.
+[[nodiscard]] std::optional<QString> open_file_dialog(
+    QWidget* parent = nullptr,
+    const FileDialogOptions& opts = FileDialogOptions{}
+);
+
+/// Modal save-file dialog. Call from the GUI thread only.
+[[nodiscard]] std::optional<QString> save_file_dialog(
+    QWidget* parent = nullptr,
+    const FileDialogOptions& opts = FileDialogOptions{}
+);
+
+} // namespace ngin::editor


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds new Qt dialog helpers and wires them into new menu actions, without changing scene persistence or core engine behavior.
> 
> **Overview**
> Adds a small `ngin::editor` file-dialog utility (`open_file_dialog`/`save_file_dialog`) with configurable `FileDialogOptions` (title, directory, filter, default name/suffix).
> 
> Wires a new **File** menu into the editor window with **Open**/**Save** actions (standard shortcuts) that invoke these dialogs and currently only log the selected path.
> 
> Updates the editor build configuration to compile the new dialog module, and extends `.gitignore` to exclude `build-fetch/` and `build-verify/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bede341d94075fa75cd492cfd3c5de9d1141c18b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->